### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export function set(object, path, value) {
     var key = toKey(path[index])
 
     if (index !== lastIndex) {
-      var objValue = nested[key]
+      var objValue = isPrototypePolluted(key) ? {} : nested[key]
       if (objValue && isObject(objValue)) {
         if (!objValue.hasOwnProperty('__ob__')) {
           Vue.set(nested, key, objValue)
@@ -38,6 +38,8 @@ export function set(object, path, value) {
   }
   return object
 }
+
+const isPrototypePolluted = (key) => /^__proto__|constructor|prototype$/.test(key);
 
 export { default as get } from 'lodash-es/get.js'
 


### PR DESCRIPTION
### :bar_chart: Metadata *

`vue-set-get` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-vue-set-get

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { set } = require('vue-set-get')

console.log('Before: ' + {}.polluted)
set({}, '__proto__.polluted', true)
console.log('After: ' + {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i vue-set-get # Install vulerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/105576045-18f32e80-5d96-11eb-9e56-8c37a645a3d0.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
